### PR TITLE
Fix quotes to be displayed correctly

### DIFF
--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -27,7 +27,7 @@
 
     <!-- String match strategies -->
     <string name="string_match_strategy_substring">通常</string>
-    <string name="string_match_strategy_skipped_substring">一部一致 （例： &quot;abd&quot; で &quot;abcdef&quot; がヒット）</string>
+    <string name="string_match_strategy_skipped_substring">一部一致 （例： \"abd\" で \"abcdef\" がヒット）</string>
 
     <!-- Notification for OS -->
     <string name="notification_launch_this_app">Blue Line Console を起動</string>
@@ -77,7 +77,7 @@
     <string name="preferences_url_add_button">URL 追加</string>
 
     <!-- Error messages, user errors -->
-    <string name="error_invalid_url_least_validation_for_web">URL の形式が不正です： https:// か http:// で始まり、もう一つ以上スラッシュ ("/") を含む必要があります</string>
+    <string name="error_invalid_url_least_validation_for_web">URL の形式が不正です： https:// か http:// で始まり、もう一つ以上スラッシュ (\"/\") を含む必要があります</string>
     <string name="error_invalid_url_command_name">コマンドはアルファベットの小文字と数字だけを含むことができ、一文字以上である必要があります。</string>
     <string name="error_empty_display_name">表示名が空です。</string>
 

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -27,7 +27,7 @@
 
     <!-- String match strategies -->
     <string name="string_match_strategy_substring">正常</string>
-    <string name="string_match_strategy_skipped_substring">跳跃子字符串（如，搜索 &quot;abd&quot; 显示 &quot;abcdef&quot;）</string>
+    <string name="string_match_strategy_skipped_substring">跳跃子字符串（如，搜索 \"abd\" 显示 \"abcdef\"）</string>
 
     <!-- Notification for OS -->
     <string name="notification_launch_this_app">启动 Blue Line Console</string>
@@ -77,7 +77,7 @@
     <string name="preferences_url_column_has_query">搜索引擎(启用后，查询将被添加在末尾)</string>
 
     <!-- Error messages, user errors -->
-    <string name="error_invalid_url_least_validation_for_web">无效的 URL：必须以 https:// 或 http:// 开头且至少再多一条斜杠("/").</string>
+    <string name="error_invalid_url_least_validation_for_web">无效的 URL：必须以 https:// 或 http:// 开头且至少再多一条斜杠(\"/\").</string>
     <string name="error_invalid_url_command_name">无效的名称：命令只能包含数字和小写字母，且不能为空。</string>
     <string name="error_empty_display_name">显示名称为空</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,7 +19,7 @@
     <string name="result_config_summary">Preferences for Blue Line Console</string>
 
     <!-- Themes -->
-    <string name="theme_name_default">Defalt (Light or Dark, according to system setting)</string>
+    <string name="theme_name_default">Default (Light or Dark, according to system setting)</string>
     <string name="theme_name_light">Light</string>
     <string name="theme_name_dark">Dark</string>
     <string name="theme_name_marine">Marine</string>
@@ -27,7 +27,7 @@
 
     <!-- String match strategies -->
     <string name="string_match_strategy_substring">Normal</string>
-    <string name="string_match_strategy_skipped_substring">Skipped substring (e.g. &quot;abd&quot; for &quot;abcdef&quot;)</string>
+    <string name="string_match_strategy_skipped_substring">Skipped substring (e.g. \"abd\" for \"abcdef\")</string>
 
     <!-- Notification for OS -->
     <string name="notification_launch_this_app">Launch Blue Line Console</string>
@@ -77,7 +77,7 @@
     <string name="preferences_url_column_has_query">Search engine (query is added at the end when enabled)</string>
 
     <!-- Error messages, user errors -->
-    <string name="error_invalid_url_least_validation_for_web">Invalid URL: must start with https:// or http:// and at least one more slash ("/").</string>
+    <string name="error_invalid_url_least_validation_for_web">Invalid URL: must start with https:// or http:// and at least one more slash (\"/\").</string>
     <string name="error_invalid_url_command_name">Invalid name: command can contain only digits and lower alphabets, and must not be empty</string>
     <string name="error_empty_display_name">Display name is empty</string>
 


### PR DESCRIPTION
Some quotes were not displayed.

Just writing `"` was simply mistake. `&quot;` was documented to be displayed as quote in the following document, but it seems it does not actually.

https://developer.android.com/guide/topics/resources/string-resource#FormattingAndStyling