### PR TITLE
minor behavior improvement and fix EditText focus problem

### DIFF
--- a/app/src/main/java/net/nhiroki/bluelineconsole/applicationMain/BaseWindowActivity.java
+++ b/app/src/main/java/net/nhiroki/bluelineconsole/applicationMain/BaseWindowActivity.java
@@ -125,7 +125,7 @@ public class BaseWindowActivity extends AppCompatActivity {
         mainViewStub.setLayoutResource(this._mainLayoutResID);
         mainViewStub.inflate();
 
-        this.findViewById(R.id.baseWindowRootLinearLayout).setOnClickListener(new ExitOnClickListener());
+        this.findViewById(R.id.baseWindowMainLayoutRoot).setOnClickListener(new ExitOnClickListener());
         ((LinearLayout)findViewById(R.id.baseWindowMainLinearLayout)).getChildAt(0).setOnClickListener(null);
 
         if (! this.getCurrentTheme().equals(PREF_VALUE_THEME_OLD_COMPUTER)) {
@@ -327,6 +327,10 @@ public class BaseWindowActivity extends AppCompatActivity {
         ((ViewGroup) findViewById(R.id.baseWindowHeaderWrapper)).getLayoutTransition().enableTransitionType(LayoutTransition.CHANGING);
         if (! this.getCurrentTheme().equals(PREF_VALUE_THEME_OLD_COMPUTER) && !this.getCurrentTheme().equals(PREF_VALUE_THEME_MARINE)) {
             ((ViewGroup) findViewById(R.id.baseWindowMainLinearLayoutOuter)).getLayoutTransition().enableTransitionType(LayoutTransition.CHANGING);
+            ((ViewGroup) findViewById(R.id.baseWindowDefaultThemeHeaderStartAccent)).getLayoutTransition().enableTransitionType(LayoutTransition.CHANGING);
+            ((ViewGroup) findViewById(R.id.baseWindowDefaultThemeFooterEndAccent)).getLayoutTransition().enableTransitionType(LayoutTransition.CHANGING);
+            ((ViewGroup) findViewById(R.id.baseWindowDefaultThemeHeaderImagePart)).getLayoutTransition().enableTransitionType(LayoutTransition.CHANGING);
+            ((ViewGroup) findViewById(R.id.baseWindowDefaultThemeFooterImagePart)).getLayoutTransition().enableTransitionType(LayoutTransition.CHANGING);
         }
         ((ViewGroup) findViewById(R.id.baseWindowMainLinearLayout)).getLayoutTransition().enableTransitionType(LayoutTransition.CHANGING);
         ((ViewGroup) findViewById(R.id.baseWindowFooterWrapper)).getLayoutTransition().enableTransitionType(LayoutTransition.CHANGING);
@@ -338,6 +342,10 @@ public class BaseWindowActivity extends AppCompatActivity {
         ((ViewGroup) findViewById(R.id.baseWindowHeaderWrapper)).getLayoutTransition().disableTransitionType(LayoutTransition.CHANGING);
         if (! this.getCurrentTheme().equals(PREF_VALUE_THEME_OLD_COMPUTER) && this.getCurrentTheme().equals(PREF_VALUE_THEME_MARINE)) {
             ((ViewGroup) findViewById(R.id.baseWindowMainLinearLayoutOuter)).getLayoutTransition().disableTransitionType(LayoutTransition.CHANGING);
+            ((ViewGroup) findViewById(R.id.baseWindowDefaultThemeHeaderStartAccent)).getLayoutTransition().disableTransitionType(LayoutTransition.CHANGING);
+            ((ViewGroup) findViewById(R.id.baseWindowDefaultThemeFooterEndAccent)).getLayoutTransition().disableTransitionType(LayoutTransition.CHANGING);
+            ((ViewGroup) findViewById(R.id.baseWindowDefaultThemeHeaderImagePart)).getLayoutTransition().disableTransitionType(LayoutTransition.CHANGING);
+            ((ViewGroup) findViewById(R.id.baseWindowDefaultThemeFooterImagePart)).getLayoutTransition().disableTransitionType(LayoutTransition.CHANGING);
         }
         ((ViewGroup) findViewById(R.id.baseWindowMainLinearLayout)).getLayoutTransition().disableTransitionType(LayoutTransition.CHANGING);
         ((ViewGroup) findViewById(R.id.baseWindowFooterWrapper)).getLayoutTransition().disableTransitionType(LayoutTransition.CHANGING);

--- a/app/src/main/java/net/nhiroki/bluelineconsole/applicationMain/CandidateListAdapter.java
+++ b/app/src/main/java/net/nhiroki/bluelineconsole/applicationMain/CandidateListAdapter.java
@@ -72,15 +72,10 @@ class CandidateListAdapter extends ArrayAdapter<CandidateEntry> {
         convertView.setBackgroundColor((position == getChosenNowExplicitly())?  selectedItemBackground.data: Color.TRANSPARENT);
 
         if (cand.getIcon(getContext()) == null) {
-            convertView.findViewById(R.id.candidateIconView).setPaddingRelative(0, 0, 0, 0);
-
             iconView.setImageResource(android.R.color.transparent);
             iconView.setVisibility(View.GONE);
+
         } else {
-            int iconViewPadding = (int)(10 * getContext().getResources().getDisplayMetrics().density + 0.5);
-
-            convertView.findViewById(R.id.candidateIconView).setPaddingRelative(0, iconViewPadding, iconViewPadding / 4, iconViewPadding);
-
             iconView.setImageDrawable(cand.getIcon(getContext()));
             iconView.setVisibility(View.VISIBLE);
         }
@@ -135,29 +130,14 @@ class CandidateListAdapter extends ArrayAdapter<CandidateEntry> {
         return chosenNowExplicitly;
     }
 
-    private int getSecondChoice() {
-        int first = getChosenNowExplicitly();
-        if (getChosenNowExplicitly() < 0) {
-            first = 0;
-        }
-        for (int i = first + 1; i < this.getCount(); ++i) {
-            if (this.getItem(i).hasEvent()) {
-                return i;
-            }
-        }
-
-        return CHOICE_UNAVAILABLE;
-    }
-
-    public boolean selectSecondChoice() {
-        int choice = getSecondChoice();
+    public boolean selectChosenNowAsListView() {
+        int choice = this.getChosenNowExplicitly();
 
         if (choice == CHOICE_UNAVAILABLE) {
             return false;
         }
 
         this.chosenNowExplicitly = CHOICE_KNOWN_BY_LISTVIEW;
-        this.listView.requestFocus();
         this.listView.setSelection(choice);
         return true;
     }

--- a/app/src/main/java/net/nhiroki/bluelineconsole/applicationMain/MainActivity.java
+++ b/app/src/main/java/net/nhiroki/bluelineconsole/applicationMain/MainActivity.java
@@ -54,6 +54,7 @@ public class MainActivity extends BaseWindowActivity {
 
         final EditText mainInputText = findViewById(R.id.mainInputText);
         mainInputText.requestFocus();
+        mainInputText.requestFocusFromTouch();
 
         final ListView candidateListView = findViewById(R.id.candidateListView);
         _resultCandidateListAdapter = new CandidateListAdapter(this, new ArrayList<CandidateEntry>(), candidateListView);
@@ -101,7 +102,8 @@ public class MainActivity extends BaseWindowActivity {
             public boolean onKey(View v, int keyCode, KeyEvent event) {
                 if (event.getAction() == KeyEvent.ACTION_DOWN && keyCode == KeyEvent.KEYCODE_DPAD_DOWN){
                     candidateListView.requestFocus();
-                    return MainActivity.this._resultCandidateListAdapter.selectSecondChoice();
+                    candidateListView.requestFocusFromTouch();
+                    return MainActivity.this._resultCandidateListAdapter.selectChosenNowAsListView() && candidateListView.onKeyDown(keyCode, event);
                 }
                 return false;
             }
@@ -254,6 +256,7 @@ public class MainActivity extends BaseWindowActivity {
         mainInputText.setPadding((int) (editTextSizeSp * 0.3 * pixelsPerSp), (int)(editTextSizeSp * 0.3 * pixelsPerSp), (int)(editTextSizeSp * 0.3 * pixelsPerSp), (int)(editTextSizeSp * 0.3 * pixelsPerSp));
 
         mainInputText.requestFocus();
+        mainInputText.requestFocusFromTouch();
     }
 
     private void executeSearch(CharSequence s) {

--- a/app/src/main/java/net/nhiroki/bluelineconsole/applicationMain/PreferencesAccentColorActivity.java
+++ b/app/src/main/java/net/nhiroki/bluelineconsole/applicationMain/PreferencesAccentColorActivity.java
@@ -176,21 +176,11 @@ public class PreferencesAccentColorActivity extends BaseWindowActivity {
         } else {
             ((TextView)this.findViewById(R.id.pref_accent_color_title_textview)).setText(String.format(this.getString(R.string.preferences_accent_color_theme_without_accent_color), this.getCurrentThemeName()));
 
-            findViewById(R.id.pref_accent_color_theme_default_radio_button).setEnabled(false);
-            findViewById(R.id.pref_accent_color_custom_radio_button).setEnabled(false);
-
-            this.findViewById(R.id.pref_accent_color_red_seekbar).setEnabled(false);
-            this.findViewById(R.id.pref_accent_color_green_seekbar).setEnabled(false);
-            this.findViewById(R.id.pref_accent_color_blue_seekbar).setEnabled(false);
-
+            this.findViewById(R.id.pref_accent_color_theme_default_radio_button).setVisibility(View.GONE);
             this.findViewById(R.id.pref_accent_color_restart_notification).setVisibility(View.GONE);
-
-            this.findViewById(R.id.pref_accent_color_red_decrement_button).setEnabled(false);
-            this.findViewById(R.id.pref_accent_color_red_increment_button).setEnabled(false);
-            this.findViewById(R.id.pref_accent_color_green_decrement_button).setEnabled(false);
-            this.findViewById(R.id.pref_accent_color_green_increment_button).setEnabled(false);
-            this.findViewById(R.id.pref_accent_color_blue_decrement_button).setEnabled(false);
-            this.findViewById(R.id.pref_accent_color_blue_increment_button).setEnabled(false);
+            this.findViewById(R.id.pref_accent_color_custom_radio_button).setVisibility(View.GONE);
+            this.findViewById(R.id.pref_accent_color_monitor).setVisibility(View.GONE);
+            this.findViewById(R.id.pref_accent_color_seek_bar_table).setVisibility(View.GONE);
         }
     }
 

--- a/app/src/main/res/layout/base_window_layout_default.xml
+++ b/app/src/main/res/layout/base_window_layout_default.xml
@@ -29,6 +29,9 @@
             android:layout_gravity="start"
             android:orientation="horizontal"
             android:animateLayoutChanges="true"
+            android:focusable="false"
+            android:focusableInTouchMode="false"
+            android:clickable="true"
             >
             <LinearLayout
                 android:layout_width="3sp"
@@ -36,12 +39,20 @@
                 android:id="@+id/baseWindowDefaultThemeHeaderStartAccent"
                 android:background="?bluelineconsoleAccentColor"
                 android:orientation="horizontal"
+                android:animateLayoutChanges="true"
+                android:focusable="false"
+                android:focusableInTouchMode="false"
                 />
             <LinearLayout
+                android:id="@+id/baseWindowDefaultThemeHeaderImagePart"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:background="@drawable/main_header_background"
-                android:orientation="vertical">
+                android:orientation="vertical"
+                android:animateLayoutChanges="true"
+                android:focusable="false"
+                android:focusableInTouchMode="false"
+                >
                 <!-- Sizes here must be consistent with corresponding drawables -->
                 <ImageView
                     android:layout_width="wrap_content"
@@ -49,6 +60,8 @@
                     android:id="@+id/baseWindowDefaultThemeHeaderAccent"
                     android:background="@drawable/main_header_accent"
                     tools:ignore="ContentDescription"
+                    android:focusable="false"
+                    android:focusableInTouchMode="false"
                     />
                 <TextView
                     android:clickable="false"
@@ -77,6 +90,9 @@
             android:orientation="vertical"
             android:layout_gravity="center"
             android:animateLayoutChanges="true"
+            android:focusable="false"
+            android:focusableInTouchMode="false"
+            android:clickable="true"
             >
             <LinearLayout
                 android:id="@+id/baseWindowMainLinearLayout"
@@ -88,6 +104,8 @@
                 android:orientation="vertical"
                 android:background="?bluelineconsoleFrameColor"
                 android:animateLayoutChanges="true"
+                android:focusable="false"
+                android:focusableInTouchMode="false"
                 >
                 <ViewStub
                     android:layout_width="match_parent"
@@ -110,12 +128,18 @@
             android:layout_gravity="end"
             android:orientation="horizontal"
             android:animateLayoutChanges="true"
+            android:focusable="false"
+            android:focusableInTouchMode="false"
+            android:clickable="true"
             >
             <LinearLayout
+                android:id="@+id/baseWindowDefaultThemeFooterImagePart"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:background="@drawable/main_footer_background"
-                android:orientation="vertical">
+                android:orientation="vertical"
+                android:animateLayoutChanges="true"
+                >
                 <!-- Sizes here must be consistent with corresponding drawables -->
                 <TextView
                     android:clickable="false"
@@ -137,6 +161,8 @@
                     android:layout_width="match_parent"
                     android:layout_height="0dp"
                     android:layout_weight="1"
+                    android:focusable="false"
+                    android:focusableInTouchMode="false"
                     />
                 <ImageView
                     android:id="@+id/baseWindowDefaultThemeFooterAccent"
@@ -144,6 +170,8 @@
                     android:layout_height="wrap_content"
                     android:background="@drawable/main_footer_accent"
                     tools:ignore="ContentDescription"
+                    android:focusable="false"
+                    android:focusableInTouchMode="false"
                     />
             </LinearLayout>
             <LinearLayout
@@ -152,6 +180,9 @@
                 android:layout_height="match_parent"
                 android:background="?bluelineconsoleAccentColor"
                 android:orientation="vertical"
+                android:focusable="false"
+                android:focusableInTouchMode="false"
+                android:animateLayoutChanges="true"
                 />
         </LinearLayout>
     </LinearLayout>

--- a/app/src/main/res/layout/base_window_layout_marine.xml
+++ b/app/src/main/res/layout/base_window_layout_marine.xml
@@ -28,6 +28,9 @@
             android:layout_height="wrap_content"
             android:orientation="vertical"
             android:background="@drawable/marine_main_window"
+            android:focusable="false"
+            android:focusableInTouchMode="false"
+            android:clickable="true"
             tools:ignore="UselessParent"
             >
             <LinearLayout

--- a/app/src/main/res/layout/base_window_layout_old_computer.xml
+++ b/app/src/main/res/layout/base_window_layout_old_computer.xml
@@ -26,6 +26,9 @@
             android:layout_height="2dp"
             android:orientation="horizontal"
             android:background="?bluelineconsoleAccentColor"
+            android:focusable="false"
+            android:focusableInTouchMode="false"
+            android:clickable="true"
             android:animateLayoutChanges="true"
             />
         <LinearLayout
@@ -35,6 +38,9 @@
             android:layout_gravity="start"
             android:background="?android:colorBackground"
             android:orientation="horizontal"
+            android:focusable="false"
+            android:focusableInTouchMode="false"
+            android:clickable="true"
             android:animateLayoutChanges="true"
             >
             <TextView
@@ -59,6 +65,9 @@
             android:layout_height="2dp"
             android:orientation="horizontal"
             android:background="?bluelineconsoleAccentColor"
+            android:focusable="false"
+            android:focusableInTouchMode="false"
+            android:clickable="true"
             android:animateLayoutChanges="true"
             />
         <LinearLayout
@@ -70,6 +79,9 @@
             android:layout_margin="0px"
             android:orientation="vertical"
             android:background="?android:colorBackground"
+            android:focusable="false"
+            android:focusableInTouchMode="false"
+            android:clickable="true"
             android:animateLayoutChanges="true"
             >
             <ViewStub
@@ -86,6 +98,9 @@
             android:layout_marginTop="-2dp"
             android:orientation="horizontal"
             android:background="?bluelineconsoleAccentColor"
+            android:focusable="false"
+            android:focusableInTouchMode="false"
+            android:clickable="true"
             android:animateLayoutChanges="true"
             />
     </LinearLayout>

--- a/app/src/main/res/layout/candidateentryview.xml
+++ b/app/src/main/res/layout/candidateentryview.xml
@@ -1,65 +1,65 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- This layout is mainly consist of texts, so for this file unify unit to sp in this file even if not text size -->
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_weight="1"
-    android:paddingTop="2dp"
-    android:paddingBottom="2dp"
-    android:paddingStart="10dp"
-    android:paddingEnd="10dp"
+    android:paddingVertical="7sp"
+    android:paddingHorizontal="10sp"
     android:orientation="horizontal"
     android:gravity="center_vertical"
     android:duplicateParentState="true"
+    android:focusable="false"
+    android:focusableInTouchMode="false"
     >
-
     <ImageView
         android:id="@+id/candidateIconView"
-        android:layout_width="48dp"
-        android:layout_height="48dp"
-        android:layout_margin="0dp"
+        android:layout_width="30sp"
+        android:layout_height="30sp"
+        android:layout_marginVertical="0sp"
+        android:layout_marginEnd="12sp"
+        android:padding="0sp"
         android:clickable="false"
         android:focusable="false"
+        android:focusableInTouchMode="false"
         tools:ignore="ContentDescription"
         />
-
     <LinearLayout
         android:id="@+id/candidateIntermediateLinearLayout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_gravity="center_vertical"
         android:orientation="vertical"
-        android:paddingTop="8dp"
-        android:paddingBottom="8dp"
+        android:paddingVertical="3sp"
         android:clickable="false"
         android:focusable="false"
+        android:focusableInTouchMode="false"
         >
-
         <TextView
             android:id="@+id/candidateTitleTextView"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:paddingTop="2dp"
-            android:paddingBottom="2dp"
+            android:paddingTop="2sp"
+            android:paddingBottom="2sp"
             android:clickable="false"
             android:focusable="false"
+            android:focusableInTouchMode="false"
             android:textColor="?bluelineconsoleBaseTextColor"
             />
-
         <LinearLayout
             android:id="@+id/candidatedetaillinearlistview"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:paddingStart="6dp"
-            android:paddingEnd="0dp"
+            android:paddingStart="6sp"
+            android:paddingEnd="0sp"
             android:orientation="vertical"
             android:clickable="false"
             android:focusable="false"
             android:duplicateParentState="true"
             />
-
     </LinearLayout>
-
 </LinearLayout>

--- a/app/src/main/res/layout/main_activity_body.xml
+++ b/app/src/main/res/layout/main_activity_body.xml
@@ -61,19 +61,25 @@
                 android:orientation="horizontal"
                 android:padding="20dp"
                 android:gravity="top"
+                android:focusable="false"
+                android:focusableInTouchMode="false"
                 >
                 <ProgressBar
                     android:layout_width="72dp"
                     android:layout_height="72dp"
                     android:paddingStart="0dp"
                     android:paddingEnd="20dp"
-                    style="?android:attr/progressBarStyle"/>
-
+                    style="?android:attr/progressBarStyle"
+                    android:focusable="false"
+                    android:focusableInTouchMode="false"
+                    />
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:orientation="vertical"
                     android:padding="10dp"
+                    android:focusable="false"
+                    android:focusableInTouchMode="false"
                     >
                     <TextView
                         android:layout_width="wrap_content"
@@ -83,6 +89,8 @@
                         android:text="@string/loading_main_caption"
                         android:textSize="18sp"
                         android:textColor="?bluelineconsoleBaseTextColor"
+                        android:focusable="false"
+                        android:focusableInTouchMode="false"
                         />
                     <TextView
                         android:layout_width="wrap_content"
@@ -90,6 +98,8 @@
                         android:text="@string/loading_detail_for_command_search"
                         android:textSize="15sp"
                         android:textColor="?bluelineconsoleBaseTextColor"
+                        android:focusable="false"
+                        android:focusableInTouchMode="false"
                         />
                 </LinearLayout>
             </LinearLayout>

--- a/app/src/main/res/layout/preferences_accent_color.xml
+++ b/app/src/main/res/layout/preferences_accent_color.xml
@@ -57,6 +57,7 @@
             tools:ignore="ContentDescription"
             />
         <TableLayout
+            android:id="@+id/pref_accent_color_seek_bar_table"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             >


### PR DESCRIPTION
Somehow it seems requestFocus() and requestFocusFromTouch() differs, and ridiculously behavior on physical keyboard is affected by requestFocusFromTouch().

This change decreased (and as long as tested disappeared) the case EditText loses focus in animation.

It seems Android 9 changed behavior of focus, but just reading this I couldn't find relationship between this behavior and this change. https://developer.android.com/about/versions/pie/android-9.0-changes-28