### PR TITLE
Add options for IMEs #44

### DIFF
--- a/app/src/main/java/net/nhiroki/bluelineconsole/applicationMain/PreferencesFragment.java
+++ b/app/src/main/java/net/nhiroki/bluelineconsole/applicationMain/PreferencesFragment.java
@@ -1,6 +1,7 @@
 package net.nhiroki.bluelineconsole.applicationMain;
 
 import android.content.Intent;
+import android.os.Build;
 import android.os.Bundle;
 
 import androidx.preference.ListPreference;
@@ -29,7 +30,7 @@ public class PreferencesFragment extends PreferenceFragmentCompat {
         final List<WebSearchEngine> urlListForLocale = new WebSearchEnginesDatabase(PreferencesFragment.this.getContext()).getURLListForLocale(PreferencesFragment.this.getContext().getResources().getConfiguration().locale, true);
 
         int webSearchEngineCount = 0;
-        for (WebSearchEngine e: urlListForLocale) {
+        for (WebSearchEngine e : urlListForLocale) {
             if (e.has_query) {
                 ++webSearchEngineCount;
             }
@@ -43,7 +44,7 @@ public class PreferencesFragment extends PreferenceFragmentCompat {
 
         int searchEnginePos = 1;
 
-        for (WebSearchEngine e: urlListForLocale) {
+        for (WebSearchEngine e : urlListForLocale) {
             if (e.has_query) {
                 search_engine_entry_values[searchEnginePos] = e.id_for_preference_value;
                 search_engine_entries[searchEnginePos] = e.display_name_locale_independent;
@@ -56,8 +57,8 @@ public class PreferencesFragment extends PreferenceFragmentCompat {
 
         int stringMatchStrategySize = StringMatchStrategy.STRATEGY_LIST.length;
 
-        CharSequence[]  string_match_strategy_entries = new CharSequence[stringMatchStrategySize];
-        CharSequence[]  string_match_strategy_entry_values = new CharSequence[stringMatchStrategySize];
+        CharSequence[] string_match_strategy_entries = new CharSequence[stringMatchStrategySize];
+        CharSequence[] string_match_strategy_entry_values = new CharSequence[stringMatchStrategySize];
 
         for (int i = 0; i < stringMatchStrategySize; ++i) {
             string_match_strategy_entries[i] = StringMatchStrategy.getStrategyName(this.getActivity(), StringMatchStrategy.STRATEGY_LIST[i]);
@@ -73,7 +74,7 @@ public class PreferencesFragment extends PreferenceFragmentCompat {
                     public boolean onPreferenceClick(Preference preference) {
                         // Not a perfect behavior, main window disappears
                         // This config is not to be used everyday, it is enough if just not too confusing
-                        ((PreferencesActivity)PreferencesFragment.this.getActivity()).setComingBackFlag();
+                        ((PreferencesActivity) PreferencesFragment.this.getActivity()).setComingBackFlag();
                         Intent intent = new Intent(ACTION_VOICE_INPUT_SETTINGS);
                         PreferencesFragment.this.startActivity(intent);
                         return true;
@@ -93,5 +94,9 @@ public class PreferencesFragment extends PreferenceFragmentCompat {
                     }
                 }
         );
+
+        if (Build.VERSION.SDK_INT < 24) {
+            findPreference(MainActivity.PREF_KEY_MAIN_EDITTEXT_HINT_LOCALE_ENGLISH).setVisible(false);
+        }
     }
 }

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -56,6 +56,7 @@
     <string name="preferences_category_apps">アプリ起動</string>
     <string name="preferences_category_appearance">外観</string>
     <string name="preferences_category_urls">Web ページと Web 検索</string>
+    <string name="preferences_category_advanced">上級者向けオプション</string>
 
     <!-- Preferences, titles for headers and footers -->
     <string name="preferences_item_main_show_startup_help_title">起動時にヘルプを表示</string>
@@ -75,6 +76,10 @@
     <string name="preferences_item_default_search_title">デフォルト検索エンジン</string>
     <string name="preferences_item_default_search_summary">常に設定した検索エンジンでの検索を一覧に表示します</string>
     <string name="preferences_item_default_search_option_none">（なし）</string>
+    <string name="preferences_item_advanced_main_edittext_flagforceascii_title">コマンド入力窓で IME_FLAG_FORCE_ASCII を有効にする</string>
+    <string name="preferences_item_advanced_main_edittext_flagforceascii_summary">IME_FLAG_FORCE_ASCII は ASCII 文字（英数、記号）入力を IME に指示するものですが IME により挙動が異なります。</string>
+    <string name="preferences_item_advanced_main_edittext_hint_locale_english_title">コマンド入力窓で、 IME に指示する言語を英語にする</string>
+    <string name="preferences_item_advanced_main_edittext_hint_locale_english_summary">コマンド入力窓で setImeHintLocales を用いて、 IME に英語入力であると指示します。IME により挙動が異なります。</string>
 
     <!-- Preferences items, URL screens -->
     <string name="preferences_url_add_button">URL 追加</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -56,6 +56,7 @@
     <string name="preferences_category_appearance">外观</string>
     <string name="preferences_category_apps">启动应用</string>
     <string name="preferences_category_urls">网页和搜索</string>
+    <string name="preferences_category_advanced">Advanced</string>
 	
     <!-- Preferences items, main screen -->
     <string name="preferences_item_main_show_startup_help_title">应用启动时显示帮助</string>
@@ -75,6 +76,10 @@
     <string name="preferences_item_default_search_title">默认搜索引擎</string>
     <string name="preferences_item_default_search_summary">总是在列表的底部显示特定的搜索引擎</string>
     <string name="preferences_item_default_search_option_none">（无）</string>
+    <string name="preferences_item_advanced_main_edittext_flagforceascii_title">Set IME_FLAG_FORCE_ASCII flag on command input window</string>
+    <string name="preferences_item_advanced_main_edittext_flagforceascii_summary">IME_FLAG_FORCE_ASCII is intended to use ASCII characters for input. Behavior differs between IMEs.</string>
+    <string name="preferences_item_advanced_main_edittext_hint_locale_english_title">Notify IME as English input on command input window</string>
+    <string name="preferences_item_advanced_main_edittext_hint_locale_english_summary">Command input window uses setImeHintLocales and sets to English locale. Behavior differs between IMEs.</string>
 
     <!-- Preferences items, URL screens -->
     <string name="preferences_url_add_button">添加自定义 URL 或搜索引擎</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -56,6 +56,7 @@
     <string name="preferences_category_appearance">Appearance</string>
     <string name="preferences_category_apps">Launching Apps</string>
     <string name="preferences_category_urls">Web Pages and Searches</string>
+    <string name="preferences_category_advanced">Advanced</string>
 
     <!-- Preferences items, main screen -->
     <string name="preferences_item_main_show_startup_help_title">Show help on startup</string>
@@ -75,6 +76,10 @@
     <string name="preferences_item_default_search_title">Default Search Engine</string>
     <string name="preferences_item_default_search_summary">Always show specific search engine on the bottom of list</string>
     <string name="preferences_item_default_search_option_none">(None)</string>
+    <string name="preferences_item_advanced_main_edittext_flagforceascii_title">Set IME_FLAG_FORCE_ASCII flag on command input window</string>
+    <string name="preferences_item_advanced_main_edittext_flagforceascii_summary">IME_FLAG_FORCE_ASCII is intended to use ASCII characters for input. Behavior differs between IMEs.</string>
+    <string name="preferences_item_advanced_main_edittext_hint_locale_english_title">Notify IME as English input on command input window</string>
+    <string name="preferences_item_advanced_main_edittext_hint_locale_english_summary">Command input window uses setImeHintLocales and sets to English locale. Behavior differs between IMEs.</string>
 
     <!-- Preferences items, URL screens -->
     <string name="preferences_url_add_button">Add custom URL or search engine</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -5,7 +5,6 @@
     >
     <PreferenceCategory
         android:title="@string/preferences_category_main"
-        android:key="pref_main_category"
         app:iconSpaceReserved="false"
         >
         <SwitchPreference
@@ -65,7 +64,6 @@
     </PreferenceCategory>
     <PreferenceCategory
         android:title="@string/preferences_category_apps"
-        android:key="pref_apps_category"
         app:iconSpaceReserved="false"
         >
         <SwitchPreference
@@ -78,7 +76,6 @@
     </PreferenceCategory>
     <PreferenceCategory
         android:title="@string/preferences_category_urls"
-        android:key="pref_urls_category"
         app:iconSpaceReserved="false"
         >
         <Preference
@@ -95,6 +92,25 @@
             android:defaultValue="none"
             android:title="@string/preferences_item_default_search_title"
             android:summary="@string/preferences_item_default_search_summary"
+            app:iconSpaceReserved="false"
+            />
+    </PreferenceCategory>
+    <PreferenceCategory
+        android:title="@string/preferences_category_advanced"
+        app:iconSpaceReserved="false"
+        >
+        <SwitchPreference
+            android:key="pref_mainedittext_flagforceascii"
+            android:title="@string/preferences_item_advanced_main_edittext_flagforceascii_title"
+            android:summary="@string/preferences_item_advanced_main_edittext_flagforceascii_summary"
+            android:defaultValue="false"
+            app:iconSpaceReserved="false"
+            />
+        <SwitchPreference
+            android:key="pref_mainedittext_hint_locale_english"
+            android:title="@string/preferences_item_advanced_main_edittext_hint_locale_english_title"
+            android:summary="@string/preferences_item_advanced_main_edittext_hint_locale_english_summary"
+            android:defaultValue="false"
             app:iconSpaceReserved="false"
             />
     </PreferenceCategory>


### PR DESCRIPTION
`flagForceAscii` sometimes does not user to input language other than English. So this is not good as default. But some IME (at least Wnn Keyboard Lab) switches to English by default and switchable to another language. This should be chosen as option.

Locale hint to IME seems to work in much better way in Gboard, but Wnn Keyboard Lab had different behavior with flagForceAscii.

So adding both as options, and make default as "default" state as possible.