### PR TITLE
Hide disabled apps

### DIFF
--- a/app/src/main/java/net/nhiroki/bluelineconsole/commands/applications/ApplicationDatabase.java
+++ b/app/src/main/java/net/nhiroki/bluelineconsole/commands/applications/ApplicationDatabase.java
@@ -122,6 +122,9 @@ public class ApplicationDatabase {
 
         List <ApplicationInfo> applicationInfoList = packageManager.getInstalledApplications(0);
         for (ApplicationInfo applicationInfo : applicationInfoList) {
+            if (! applicationInfo.enabled) {
+                continue;
+            }
 
             PackageInfo packageInfo;
             try {


### PR DESCRIPTION
This affects nothing on my ends, but better if affects.

https://developer.android.com/reference/android/content/pm/ApplicationInfo#enabled

As long as beliving the document, when enabled attr is false, the app
can be ignored totally.