### PR TITLE
Split calculator lib to specific directory

### DIFF
--- a/app/src/main/java/net/nhiroki/bluelineconsole/commandSearchers/CalculatorCommandSearcher.java
+++ b/app/src/main/java/net/nhiroki/bluelineconsole/commandSearchers/CalculatorCommandSearcher.java
@@ -12,9 +12,9 @@ import androidx.annotation.NonNull;
 import androidx.core.util.Pair;
 
 import net.nhiroki.bluelineconsole.R;
-import net.nhiroki.bluelineconsole.commands.calculator.Calculator;
-import net.nhiroki.bluelineconsole.commands.calculator.CalculatorExceptions;
-import net.nhiroki.bluelineconsole.commands.calculator.CalculatorNumber;
+import net.nhiroki.lib.bluelinecalculator.Calculator;
+import net.nhiroki.lib.bluelinecalculator.CalculatorExceptions;
+import net.nhiroki.lib.bluelinecalculator.CalculatorNumber;
 import net.nhiroki.bluelineconsole.interfaces.CandidateEntry;
 import net.nhiroki.bluelineconsole.interfaces.CommandSearcher;
 import net.nhiroki.bluelineconsole.interfaces.EventLauncher;

--- a/app/src/main/java/net/nhiroki/bluelineconsole/commands/calculator/FormulaPart.java
+++ b/app/src/main/java/net/nhiroki/bluelineconsole/commands/calculator/FormulaPart.java
@@ -1,5 +1,0 @@
-package net.nhiroki.bluelineconsole.commands.calculator;
-
-public interface FormulaPart {
-
-}

--- a/app/src/main/java/net/nhiroki/lib/bluelinecalculator/Calculator.java
+++ b/app/src/main/java/net/nhiroki/lib/bluelinecalculator/Calculator.java
@@ -1,7 +1,7 @@
-package net.nhiroki.bluelineconsole.commands.calculator;
+package net.nhiroki.lib.bluelinecalculator;
 
-import net.nhiroki.bluelineconsole.commands.calculator.units.CombinedUnit;
-import net.nhiroki.bluelineconsole.commands.calculator.units.UnitDirectory;
+import net.nhiroki.lib.bluelinecalculator.units.CombinedUnit;
+import net.nhiroki.lib.bluelinecalculator.units.UnitDirectory;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;

--- a/app/src/main/java/net/nhiroki/lib/bluelinecalculator/CalculatorExceptions.java
+++ b/app/src/main/java/net/nhiroki/lib/bluelinecalculator/CalculatorExceptions.java
@@ -1,8 +1,8 @@
-package net.nhiroki.bluelineconsole.commands.calculator;
+package net.nhiroki.lib.bluelinecalculator;
 
 import androidx.annotation.NonNull;
 
-import net.nhiroki.bluelineconsole.commands.calculator.units.CombinedUnit;
+import net.nhiroki.lib.bluelinecalculator.units.CombinedUnit;
 
 public class CalculatorExceptions {
     public static class IllegalFormulaException extends Exception {}

--- a/app/src/main/java/net/nhiroki/lib/bluelinecalculator/CalculatorNumber.java
+++ b/app/src/main/java/net/nhiroki/lib/bluelinecalculator/CalculatorNumber.java
@@ -1,10 +1,10 @@
-package net.nhiroki.bluelineconsole.commands.calculator;
+package net.nhiroki.lib.bluelinecalculator;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import net.nhiroki.bluelineconsole.commands.calculator.units.CombinedUnit;
-import net.nhiroki.bluelineconsole.commands.calculator.units.UnitDirectory;
+import net.nhiroki.lib.bluelinecalculator.units.CombinedUnit;
+import net.nhiroki.lib.bluelinecalculator.units.UnitDirectory;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;

--- a/app/src/main/java/net/nhiroki/lib/bluelinecalculator/FormulaPart.java
+++ b/app/src/main/java/net/nhiroki/lib/bluelinecalculator/FormulaPart.java
@@ -1,0 +1,5 @@
+package net.nhiroki.lib.bluelinecalculator;
+
+public interface FormulaPart {
+
+}

--- a/app/src/main/java/net/nhiroki/lib/bluelinecalculator/Operator.java
+++ b/app/src/main/java/net/nhiroki/lib/bluelinecalculator/Operator.java
@@ -1,4 +1,4 @@
-package net.nhiroki.bluelineconsole.commands.calculator;
+package net.nhiroki.lib.bluelinecalculator;
 
 public interface Operator extends FormulaPart {
     int getPriority(); // strictly greater than 0

--- a/app/src/main/java/net/nhiroki/lib/bluelinecalculator/ParseResult.java
+++ b/app/src/main/java/net/nhiroki/lib/bluelinecalculator/ParseResult.java
@@ -1,4 +1,4 @@
-package net.nhiroki.bluelineconsole.commands.calculator;
+package net.nhiroki.lib.bluelinecalculator;
 
 public class ParseResult {
     private final FormulaPart formulaPart;

--- a/app/src/main/java/net/nhiroki/lib/bluelinecalculator/units/CombinedUnit.java
+++ b/app/src/main/java/net/nhiroki/lib/bluelinecalculator/units/CombinedUnit.java
@@ -1,11 +1,11 @@
-package net.nhiroki.bluelineconsole.commands.calculator.units;
+package net.nhiroki.lib.bluelinecalculator.units;
 
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import net.nhiroki.bluelineconsole.commands.calculator.CalculatorExceptions;
-import net.nhiroki.bluelineconsole.commands.calculator.CalculatorNumber;
+import net.nhiroki.lib.bluelinecalculator.CalculatorExceptions;
+import net.nhiroki.lib.bluelinecalculator.CalculatorNumber;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/app/src/main/java/net/nhiroki/lib/bluelinecalculator/units/Unit.java
+++ b/app/src/main/java/net/nhiroki/lib/bluelinecalculator/units/Unit.java
@@ -1,11 +1,11 @@
-package net.nhiroki.bluelineconsole.commands.calculator.units;
+package net.nhiroki.lib.bluelinecalculator.units;
 
 import java.math.BigDecimal;
 
 import androidx.annotation.NonNull;
 
-import net.nhiroki.bluelineconsole.commands.calculator.CalculatorExceptions;
-import net.nhiroki.bluelineconsole.commands.calculator.CalculatorNumber;
+import net.nhiroki.lib.bluelinecalculator.CalculatorExceptions;
+import net.nhiroki.lib.bluelinecalculator.CalculatorNumber;
 
 public interface Unit extends Comparable<Unit> {
     String getUnitName();

--- a/app/src/main/java/net/nhiroki/lib/bluelinecalculator/units/UnitDirectory.java
+++ b/app/src/main/java/net/nhiroki/lib/bluelinecalculator/units/UnitDirectory.java
@@ -1,10 +1,10 @@
-package net.nhiroki.bluelineconsole.commands.calculator.units;
+package net.nhiroki.lib.bluelinecalculator.units;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import net.nhiroki.bluelineconsole.commands.calculator.CalculatorExceptions;
-import net.nhiroki.bluelineconsole.commands.calculator.CalculatorNumber;
+import net.nhiroki.lib.bluelinecalculator.CalculatorExceptions;
+import net.nhiroki.lib.bluelinecalculator.CalculatorNumber;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;

--- a/app/src/test/java/net/nhiroki/bluelineconsole/CalculatorUnitTests.java
+++ b/app/src/test/java/net/nhiroki/bluelineconsole/CalculatorUnitTests.java
@@ -7,14 +7,13 @@ import static org.junit.Assert.*;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
-import java.math.BigDecimal;
 import java.util.List;
 
-import net.nhiroki.bluelineconsole.commands.calculator.Calculator;
-import net.nhiroki.bluelineconsole.commands.calculator.CalculatorExceptions;
-import net.nhiroki.bluelineconsole.commands.calculator.CalculatorNumber;
-import net.nhiroki.bluelineconsole.commands.calculator.Operator;
-import net.nhiroki.bluelineconsole.commands.calculator.ParseResult;
+import net.nhiroki.lib.bluelinecalculator.Calculator;
+import net.nhiroki.lib.bluelinecalculator.CalculatorExceptions;
+import net.nhiroki.lib.bluelinecalculator.CalculatorNumber;
+import net.nhiroki.lib.bluelinecalculator.Operator;
+import net.nhiroki.lib.bluelinecalculator.ParseResult;
 
 
 public class CalculatorUnitTests {


### PR DESCRIPTION
Split calculator libraries into net.nhiroki.lib.bluelinecalculator.

Still depends on androidx.annotation for Null treatment, but these are
just for compilers. For now keeping them and postponing spliting
completely removing androidx dependency.