### PR TITLE
Revert "FragmentActivity instead of AppCompatActivity"

### DIFF
--- a/app/src/main/java/net/nhiroki/bluelineconsole/applicationMain/BaseWindowActivity.java
+++ b/app/src/main/java/net/nhiroki/bluelineconsole/applicationMain/BaseWindowActivity.java
@@ -21,14 +21,14 @@ import android.widget.TextView;
 
 import androidx.annotation.CallSuper;
 import androidx.annotation.LayoutRes;
+import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.app.AppCompatDelegate;
 import androidx.core.graphics.drawable.DrawableCompat;
-import androidx.fragment.app.FragmentActivity;
 
 import net.nhiroki.bluelineconsole.R;
 
 
-public class BaseWindowActivity extends FragmentActivity {
+public class BaseWindowActivity extends AppCompatActivity {
     protected boolean _iAmHomeActivity = false;
 
     private final @LayoutRes int _mainLayoutResID;


### PR DESCRIPTION
This reverts commit 9b5a278d22a9fb62d0d5463bccd34d6db814ecac.

Dark mode did not work on older Android.