### PR TITLE
Set GitHub Action job name

### DIFF
--- a/.github/workflows/android-connectedcheck.yml
+++ b/.github/workflows/android-connectedcheck.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   test:
+    name: Android connectedCheck
+
     runs-on: macos-latest
     steps:
       - name: checkout

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   build:
+    name: Basic Gradle test
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
It seems necessary to use in branch protection
https://stackoverflow.com/questions/68554735/github-action-status-check-missing-from-the-list-of-checks-in-protected-branch-s