### PR TITLE
Fix opening incorrect position when HeaderView exists

### DIFF
--- a/app/src/main/java/net/nhiroki/bluelineconsole/applicationMain/MainActivity.java
+++ b/app/src/main/java/net/nhiroki/bluelineconsole/applicationMain/MainActivity.java
@@ -173,7 +173,7 @@ public class MainActivity extends BaseWindowActivity {
          *   - ListView.mHeaderViewInfos and HeaderViewListAdapter.mHeaderViewInfos may be different objects, and HeaderViewListAdapter.mHeaderViewInfos is actually used.
          */
 
-        HeaderViewListAdapter internalHeaderAdapter = new HeaderViewListAdapter(headerViewInfos, null, _resultCandidateListAdapter) {
+        final HeaderViewListAdapter internalHeaderAdapter = new HeaderViewListAdapter(headerViewInfos, null, _resultCandidateListAdapter) {
             @Override
             public boolean isEnabled(int position) {
                 try {
@@ -198,7 +198,7 @@ public class MainActivity extends BaseWindowActivity {
         candidateListView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
             @Override
             public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
-                _resultCandidateListAdapter.invokeEvent(position, MainActivity.this);
+                _resultCandidateListAdapter.invokeEvent(position - internalHeaderAdapter.getHeadersCount(), MainActivity.this);
             }
         });
 


### PR DESCRIPTION
Previous code does not consider the difference of index between ListView
click and internal main ArrayAdapter, caused by HeaderViewListAdapter.

Issue: https://github.com/nhirokinet/bluelineconsole/issues/157

This commit fixes the bug.