### PR TITLE
Make ping act as normal terminal

### DIFF
--- a/app/src/main/java/net/nhiroki/bluelineconsole/commands/netutils/Ping6Activity.java
+++ b/app/src/main/java/net/nhiroki/bluelineconsole/commands/netutils/Ping6Activity.java
@@ -3,6 +3,7 @@ package net.nhiroki.bluelineconsole.commands.netutils;
 import android.annotation.SuppressLint;
 import android.content.Intent;
 import android.os.Bundle;
+import android.view.View;
 import android.widget.TextView;
 
 import net.nhiroki.bluelineconsole.R;
@@ -39,6 +40,10 @@ public class Ping6Activity extends BaseWindowActivity {
 
         this.changeBaseWindowElementSizeForAnimation(false);
         this.enableBaseWindowAnimation();
+
+        // Invert scroolview position because ScrollView itself is invertd
+        boolean isRtl = this.getResources().getConfiguration().getLayoutDirection() == View.LAYOUT_DIRECTION_RTL;
+        this.findViewById(R.id.command_output_scroll_view).setVerticalScrollbarPosition(isRtl ? View.SCROLLBAR_POSITION_RIGHT: View.SCROLLBAR_POSITION_LEFT);
     }
 
     @SuppressLint("SetTextI18n")

--- a/app/src/main/java/net/nhiroki/bluelineconsole/commands/netutils/PingActivity.java
+++ b/app/src/main/java/net/nhiroki/bluelineconsole/commands/netutils/PingActivity.java
@@ -3,6 +3,7 @@ package net.nhiroki.bluelineconsole.commands.netutils;
 import android.annotation.SuppressLint;
 import android.content.Intent;
 import android.os.Bundle;
+import android.view.View;
 import android.widget.TextView;
 
 import net.nhiroki.bluelineconsole.R;
@@ -39,6 +40,10 @@ public class PingActivity extends BaseWindowActivity {
 
         this.changeBaseWindowElementSizeForAnimation(false);
         this.enableBaseWindowAnimation();
+
+        // Invert scroolview position because ScrollView itself is invertd
+        boolean isRtl = this.getResources().getConfiguration().getLayoutDirection() == View.LAYOUT_DIRECTION_RTL;
+        this.findViewById(R.id.command_output_scroll_view).setVerticalScrollbarPosition(isRtl ? View.SCROLLBAR_POSITION_RIGHT: View.SCROLLBAR_POSITION_LEFT);
     }
 
     @SuppressLint("SetTextI18n")

--- a/app/src/main/res/layout/activity_ping.xml
+++ b/app/src/main/res/layout/activity_ping.xml
@@ -1,12 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="?android:colorBackground"
     android:orientation="vertical"
-    tools:ignore="Overdraw"
     >
     <TextView
         android:id="@+id/command_title_text_view"
@@ -16,11 +14,13 @@
         android:background="?bluelineconsoleFrameColor"
         android:padding="3sp"
         />
-    <!-- TODO: make it scrollable -->
-    <LinearLayout
+    <!-- To make ScrollView keep bottom by default, both ScrollView and contents are rotated  -->
+    <ScrollView
+        android:id="@+id/command_output_scroll_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:fillViewport="true"
+        android:rotation="180"
         >
         <TextView
             android:id="@+id/command_output_text_view"
@@ -29,8 +29,7 @@
             android:textColor="?bluelineconsoleBaseTextColor"
             android:fontFamily="monospace"
             android:padding="3sp"
-            android:layout_gravity="bottom"
-            android:gravity="bottom"
+            android:rotation="180"
             />
-    </LinearLayout>
+    </ScrollView>
 </LinearLayout>


### PR DESCRIPTION
Previous implementation of ping/ping6 did not support scroll, and if
screen is not filled, text was kept bottom. In this commit, texts are
basically go to top and keeps scrolling to bottom.