### PR TITLE
Enable lintOption abortOnError for errors

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,7 +25,7 @@ android {
         }
     }
     lintOptions {
-        abortOnError false
+        ignoreWarnings true
     }
 }
 

--- a/app/src/main/java/net/nhiroki/bluelineconsole/dataStore/cache/ApplicationInformationCache.java
+++ b/app/src/main/java/net/nhiroki/bluelineconsole/dataStore/cache/ApplicationInformationCache.java
@@ -1,5 +1,6 @@
 package net.nhiroki.bluelineconsole.dataStore.cache;
 
+import android.annotation.SuppressLint;
 import android.content.ContentValues;
 import android.content.Context;
 import android.database.Cursor;
@@ -9,6 +10,7 @@ import android.database.sqlite.SQLiteOpenHelper;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+
 
 public class ApplicationInformationCache extends SQLiteOpenHelper {
     private static final String DATABASE_NAME = "application_information_cache.sqlite";
@@ -40,6 +42,7 @@ public class ApplicationInformationCache extends SQLiteOpenHelper {
         // Nothing to do now because database structure have not been modified
     }
 
+    @SuppressLint("Range")
     public List<ApplicationInformation> getAllApplicationCaches() {
         List<ApplicationInformation> ret = new ArrayList<>();
 

--- a/app/src/main/java/net/nhiroki/bluelineconsole/dataStore/deviceLocal/WidgetsSetting.java
+++ b/app/src/main/java/net/nhiroki/bluelineconsole/dataStore/deviceLocal/WidgetsSetting.java
@@ -1,5 +1,6 @@
 package net.nhiroki.bluelineconsole.dataStore.deviceLocal;
 
+import android.annotation.SuppressLint;
 import android.appwidget.AppWidgetProviderInfo;
 import android.content.ContentValues;
 import android.content.Context;
@@ -127,6 +128,7 @@ public class WidgetsSetting extends SQLiteOpenHelper {
         return this.getWritableDatabase().insert("home_screen_widgets", null, cv);
     }
 
+    @SuppressLint("Range")
     public List<AppWidgetsHostManager.HomeScreenWidgetInfo> getAllHomeScreenWidgets(AppWidgetsHostManager appWidgetsHostManager) {
         List<AppWidgetsHostManager.HomeScreenWidgetInfo> ret = new ArrayList<>();
 
@@ -148,6 +150,7 @@ public class WidgetsSetting extends SQLiteOpenHelper {
         return ret;
     }
 
+    @SuppressLint("Range")
     public AppWidgetsHostManager.HomeScreenWidgetInfo getHomeScreenById(AppWidgetsHostManager appWidgetsHostManager, int id) {
         Cursor curEntry = this.getReadableDatabase().query("home_screen_widgets", new String[]{"id", "app_widget_id", "height_px", "after_default_item"},
                                                   "id = ?", new String[]{String.valueOf(id)}, null, null, null);
@@ -183,6 +186,7 @@ public class WidgetsSetting extends SQLiteOpenHelper {
         this.getWritableDatabase().update("home_screen_widgets", cv, "id = ?", args);
     }
 
+    @SuppressLint("Range")
     public List<AppWidgetsHostManager.WidgetCommand> getAllWidgetCommands(AppWidgetsHostManager appWidgetsHostManager) {
         List<AppWidgetsHostManager.WidgetCommand> ret = new ArrayList<>();
 
@@ -207,6 +211,7 @@ public class WidgetsSetting extends SQLiteOpenHelper {
         return ret;
     }
 
+    @SuppressLint("Range")
     public AppWidgetsHostManager.WidgetCommand getWidgetCommandById(AppWidgetsHostManager appWidgetsHostManager, int id) {
         Cursor curEntry = this.getReadableDatabase().query("widget_commands", new String[]{"id", "command", "abbreviation", "app_widget_id", "height_px"},
                                                   "id = ?", new String[]{String.valueOf(id)},  null, null, null);

--- a/app/src/main/java/net/nhiroki/bluelineconsole/dataStore/persistent/HomeScreenSetting.java
+++ b/app/src/main/java/net/nhiroki/bluelineconsole/dataStore/persistent/HomeScreenSetting.java
@@ -1,5 +1,6 @@
 package net.nhiroki.bluelineconsole.dataStore.persistent;
 
+import android.annotation.SuppressLint;
 import android.content.ContentValues;
 import android.content.Context;
 import android.database.Cursor;
@@ -75,6 +76,7 @@ public class HomeScreenSetting extends SQLiteOpenHelper {
         return this.getWritableDatabase().insert("home_screen_default_items", null, cv);
     }
 
+    @SuppressLint("Range")
     public List<HomeScreenDefaultItem> getAllHomeScreenDefaultItems() {
         List<HomeScreenDefaultItem> ret = new ArrayList<>();
 
@@ -94,6 +96,7 @@ public class HomeScreenSetting extends SQLiteOpenHelper {
         return ret;
     }
 
+    @SuppressLint("Range")
     public HomeScreenDefaultItem getHomeScreenDefaultItemById(int id) {
         Cursor curEntry = this.getReadableDatabase().query("home_screen_default_items", new String[]{"id", "type", "data"},
                 "id = ?", new String[]{String.valueOf(id)}, null, null, null);
@@ -111,6 +114,7 @@ public class HomeScreenSetting extends SQLiteOpenHelper {
         return null;
     }
 
+    @SuppressLint("Range")
     public int getLargestIdInHomeScreenDefaultItems() {
         Cursor curEntry = this.getReadableDatabase().query("home_screen_default_items", new String[]{"MAX(id)"}, null, null, null, null, "id");
         int ret = -1;

--- a/app/src/main/java/net/nhiroki/bluelineconsole/dataStore/persistent/URLPreferences.java
+++ b/app/src/main/java/net/nhiroki/bluelineconsole/dataStore/persistent/URLPreferences.java
@@ -1,5 +1,6 @@
 package net.nhiroki.bluelineconsole.dataStore.persistent;
 
+import android.annotation.SuppressLint;
 import android.content.ContentValues;
 import android.content.Context;
 import android.database.Cursor;
@@ -69,6 +70,7 @@ public class URLPreferences extends SQLiteOpenHelper {
         return this.getWritableDatabase().insert("url_info", null, cv);
     }
 
+    @SuppressLint("Range")
     public List<URLEntry> getAllEntries() {
         List<URLEntry> ret = new ArrayList<>();
 


### PR DESCRIPTION
Ignores warnings, and suppresses Range warnings for not checking -1 for
getColumnIndex, but still better than disabling completely...