### PR TITLE
Enable specialised queries to check for specific handlers

### DIFF
--- a/app/src/main/java/net/nhiroki/bluelineconsole/applicationMain/MainActivity.java
+++ b/app/src/main/java/net/nhiroki/bluelineconsole/applicationMain/MainActivity.java
@@ -1,10 +1,5 @@
 package net.nhiroki.bluelineconsole.applicationMain;
 
-import java.util.List;
-import java.util.ArrayList;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-
 import android.content.Intent;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
@@ -22,6 +17,12 @@ import net.nhiroki.bluelineconsole.applicationMain.lib.EditTextConfigurations;
 import net.nhiroki.bluelineconsole.commandSearchers.CommandSearchAggregator;
 import net.nhiroki.bluelineconsole.dataStore.deviceLocal.WidgetsSetting;
 import net.nhiroki.bluelineconsole.interfaces.CandidateEntry;
+import net.nhiroki.bluelineconsole.query.Query;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 
 public class MainActivity extends BaseWindowActivity {
@@ -285,27 +286,32 @@ public class MainActivity extends BaseWindowActivity {
     }
 
     private void executeSearch(String query) {
+        Query processedQuery = Query.from(query);
         List<CandidateEntry> candidates = new ArrayList<>();
 
-        if (! query.isEmpty()) {
-            candidates.addAll(commandSearchAggregator.searchCandidateEntries(query, MainActivity.this));
-        }
+        if(processedQuery.isSpecialised()){
+            candidates.addAll(commandSearchAggregator.searchSpecialised(processedQuery, MainActivity.this));
+        }else {
+            if (!query.isEmpty()) {
+                candidates.addAll(commandSearchAggregator.searchCandidateEntries(query, MainActivity.this));
+            }
 
-        if (this.iAmHomeActivity && query.isEmpty()) {
-            List<CandidateEntry> homeScreenEntries = commandSearchAggregator.homeScreenDefaultCandidateEntries(this);
-            candidates.addAll(homeScreenEntries);
-            this.homeItemExists = ! homeScreenEntries.isEmpty();
-        }
+            if (this.iAmHomeActivity && query.isEmpty()) {
+                List<CandidateEntry> homeScreenEntries = commandSearchAggregator.homeScreenDefaultCandidateEntries(this);
+                candidates.addAll(homeScreenEntries);
+                this.homeItemExists = ! homeScreenEntries.isEmpty();
+            }
 
-        if (! query.isEmpty()) {
-            candidates.addAll(commandSearchAggregator.searchCandidateEntriesForLast(query, this));
+            if (!query.isEmpty()) {
+                candidates.addAll(commandSearchAggregator.searchCandidateEntriesForLast(query, this));
+            }
         }
 
         resultCandidateListAdapter.clear();
         resultCandidateListAdapter.addAll(candidates);
         resultCandidateListAdapter.notifyDataSetChanged();
 
-        if (! candidates.isEmpty()) {
+        if (!candidates.isEmpty()) {
             candidateListView.setSelection(0);
         }
 

--- a/app/src/main/java/net/nhiroki/bluelineconsole/commandSearchers/eachSearcher/ApplicationCommandSearcher.java
+++ b/app/src/main/java/net/nhiroki/bluelineconsole/commandSearchers/eachSearcher/ApplicationCommandSearcher.java
@@ -22,6 +22,7 @@ import net.nhiroki.bluelineconsole.dataStore.cache.ApplicationInformation;
 import net.nhiroki.bluelineconsole.interfaces.CandidateEntry;
 import net.nhiroki.bluelineconsole.interfaces.CommandSearcher;
 import net.nhiroki.bluelineconsole.interfaces.EventLauncher;
+import net.nhiroki.bluelineconsole.query.QueryType;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -171,5 +172,10 @@ public class ApplicationCommandSearcher implements CommandSearcher {
         public boolean viewIsRecyclable() {
             return true;
         }
+    }
+
+    @Override
+    public QueryType getSpecialisation() {
+        return QueryType.APP_ONLY;
     }
 }

--- a/app/src/main/java/net/nhiroki/bluelineconsole/commandSearchers/eachSearcher/ContactSearchCommandSearcher.java
+++ b/app/src/main/java/net/nhiroki/bluelineconsole/commandSearchers/eachSearcher/ContactSearchCommandSearcher.java
@@ -17,6 +17,7 @@ import net.nhiroki.bluelineconsole.commandSearchers.lib.StringMatchStrategy;
 import net.nhiroki.bluelineconsole.interfaces.CandidateEntry;
 import net.nhiroki.bluelineconsole.interfaces.CommandSearcher;
 import net.nhiroki.bluelineconsole.interfaces.EventLauncher;
+import net.nhiroki.bluelineconsole.query.QueryType;
 import net.nhiroki.bluelineconsole.wrapperForAndroid.ContactsReader;
 
 import java.util.ArrayList;
@@ -168,6 +169,11 @@ public class ContactSearchCommandSearcher implements CommandSearcher {
             }
         }
         return ret;
+    }
+
+    @Override
+    public QueryType getSpecialisation() {
+        return QueryType.CONTACT_ONLY;
     }
 
     private static int judgeQueryForContact(Context context, String query, ContactsReader.Contact contact) {

--- a/app/src/main/java/net/nhiroki/bluelineconsole/interfaces/CommandSearcher.java
+++ b/app/src/main/java/net/nhiroki/bluelineconsole/interfaces/CommandSearcher.java
@@ -4,6 +4,9 @@ import android.content.Context;
 
 import androidx.annotation.NonNull;
 
+import net.nhiroki.bluelineconsole.query.QueryType;
+
+import java.util.Collections;
 import java.util.List;
 
 public interface CommandSearcher {
@@ -37,4 +40,9 @@ public interface CommandSearcher {
      */
     @NonNull
     List<CandidateEntry> searchCandidateEntries(String query, Context context);
+
+
+    default QueryType getSpecialisation(){
+        return QueryType.NONE;
+    };
 }

--- a/app/src/main/java/net/nhiroki/bluelineconsole/query/Query.java
+++ b/app/src/main/java/net/nhiroki/bluelineconsole/query/Query.java
@@ -1,0 +1,40 @@
+package net.nhiroki.bluelineconsole.query;
+
+public class Query{
+    protected static final String SPACE = " ";
+
+    public QueryType getType() {
+        return type;
+    }
+
+    public String getText() {
+        return text;
+    }
+
+    private final QueryType type;
+    private final String text;
+
+    public Query(QueryType type, String text) {
+        this.type = type;
+        this.text = text;
+    }
+
+    private Query(String text) {
+        String[] typeAndText = text.split(Query.SPACE, 2);
+        if(typeAndText.length == 2){
+            this.type = QueryType.fromSymbol(typeAndText[0]);
+            this.text = typeAndText[1];
+            return;
+        }
+        this.text = text;
+        this.type = QueryType.NONE;
+    }
+
+    public boolean isSpecialised() {
+        return type != null && type != QueryType.NONE;
+    }
+
+    public static Query from(String text){
+        return new Query(text);
+    }
+}

--- a/app/src/main/java/net/nhiroki/bluelineconsole/query/QueryType.java
+++ b/app/src/main/java/net/nhiroki/bluelineconsole/query/QueryType.java
@@ -1,0 +1,27 @@
+package net.nhiroki.bluelineconsole.query;
+
+
+public enum QueryType {
+    NONE(""),
+    APP_ONLY("a"),
+    CONTACT_ONLY("c")
+    ;
+
+    private final String symbol;
+
+    QueryType(String symbol) {
+        this.symbol = symbol;
+    }
+
+    public static QueryType fromSymbol(String symbol){
+        if(symbol == null){
+            return NONE;
+        }
+        for (QueryType type: values()) {
+            if(type.symbol.equals(symbol.trim())){
+                return type;
+            }
+        }
+        return NONE;
+    }
+}


### PR DESCRIPTION
The PR adds specialized queries to blueline console. Specialized queries are those types where user wants to explicitly query one type. For example, the user wants to query only apps or only contacts, then he can use the system prefix along with space, followed by the text to run the query on the preferred type. In future, we can make the prefix configurable so that users can do configure the handle. In future, we can also move the same to custom functions where user can form the function to specifically query a handler. As of now, contact only and app only queries are added which will be triggered by "c <contact query>" or "a <app query>" respectively. 