### PR TITLE
Widgets features are not experimental now

### DIFF
--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -96,7 +96,7 @@
     <string name="preferences_item_default_search_title">デフォルト検索エンジン</string>
     <string name="preferences_item_default_search_summary">常に設定した検索エンジンでの検索を一覧に表示します</string>
     <string name="preferences_item_default_search_option_none">（なし）</string>
-    <string name="preferences_item_custom_commands_widgets">ウィジェットコマンド（実験的機能）</string>
+    <string name="preferences_item_custom_commands_widgets">ウィジェットコマンド</string>
     <string name="preferences_item_home_screen_default_items">ホームスクリーンの項目</string>
     <string name="preferences_item_home_screen_default_items_summary">ホームスクリーンとして起動され、コマンドが何も入力されていない場合に表示する項目を設定します</string>
     <string name="preferences_item_contacts_enable_search">連絡先からの検索を有効にする</string>
@@ -129,7 +129,7 @@
 
     <!-- Preferences item, home screen default items screens -->
     <string name="preferences_home_screen_add_command_button">コマンドを追加する</string>
-    <string name="preferences_home_screen_add_widget_button">ウィジェットを追加する（実験的機能）</string>
+    <string name="preferences_home_screen_add_widget_button">ウィジェットを追加する</string>
     <string name="preferences_home_screen_add_widget_select_message">追加するウィジェットを選択してください</string>
     <string name="preferences_home_screen_widget_label">ウィジェット</string>
     <string name="preferences_home_screen_command_label">コマンド</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -96,7 +96,7 @@
     <string name="preferences_item_default_search_title">默认搜索引擎</string>
     <string name="preferences_item_default_search_summary">总是在列表的底部显示特定的搜索引擎</string>
     <string name="preferences_item_default_search_option_none">（无）</string>
-    <string name="preferences_item_custom_commands_widgets">小部件命令（实验性）</string>
+    <string name="preferences_item_custom_commands_widgets">小部件命令</string>
     <string name="preferences_item_home_screen_default_items">主屏项目</string>
     <string name="preferences_item_home_screen_default_items_summary">在 Blue Line Console 被设为启动器的情况下，当主屏幕上没有任何输入时，显示结果和小部件。</string>
     <string name="preferences_item_contacts_enable_search">启用联系人搜索</string>
@@ -129,7 +129,7 @@
 
     <!-- Preferences item, home screen default items screens -->
     <string name="preferences_home_screen_add_command_button">添加命令</string>
-    <string name="preferences_home_screen_add_widget_button">添加小部件 （实验性）</string>
+    <string name="preferences_home_screen_add_widget_button">添加小部件</string>
     <string name="preferences_home_screen_add_widget_select_message">选择要添加的小部件：</string>
     <string name="preferences_home_screen_widget_label">小部件</string>
     <string name="preferences_home_screen_command_label">命令</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -96,7 +96,7 @@
     <string name="preferences_item_default_search_title">Default Search Engine</string>
     <string name="preferences_item_default_search_summary">Always show specific search engine on the bottom of list</string>
     <string name="preferences_item_default_search_option_none">(None)</string>
-    <string name="preferences_item_custom_commands_widgets">Widget commands (experimental)</string>
+    <string name="preferences_item_custom_commands_widgets">Widget commands</string>
     <string name="preferences_item_home_screen_default_items">Home screen items</string>
     <string name="preferences_item_home_screen_default_items_summary">Display results and widgets when nothing is input at home screen, when Blue Line Console is set to home app.</string>
     <string name="preferences_item_contacts_enable_search">Enable contacts search</string>
@@ -129,7 +129,7 @@
 
     <!-- Preferences item, home screen default items screens -->
     <string name="preferences_home_screen_add_command_button">Add command</string>
-    <string name="preferences_home_screen_add_widget_button">Add widget (experimental)</string>
+    <string name="preferences_home_screen_add_widget_button">Add widget</string>
     <string name="preferences_home_screen_add_widget_select_message">Select widget to add:</string>
     <string name="preferences_home_screen_widget_label">Widget</string>
     <string name="preferences_home_screen_command_label">Command</string>


### PR DESCRIPTION
Widgets features had problems that sometimes shows up empty until clicked.
But after some trial about rendering from clear state, I see less cases.
That does not mean it is tested well, but no good reason to keep this experimental.
Also, I have recieved no error report about this.

Scrolling is still not working, but it is consistent behavior and yet not unchangable behavior.

Therefore, unless I receive bug report until next release, I make this feature non-experimental one.