### PR TITLE
Drop connectedCheck on Android SDK24

### DIFF
--- a/.github/workflows/android-connectedcheck.yml
+++ b/.github/workflows/android-connectedcheck.yml
@@ -13,8 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        # Not sure, API level 24 looks like some threshold for UI testing
-        api-level: [22, 24, 35]
+        api-level: [22, 35]
 
     steps:
       - name: checkout

--- a/ci/android-connectedcheck.sh
+++ b/ci/android-connectedcheck.sh
@@ -1,7 +1,6 @@
 #!/bin/bash -eux
 
 # Minimum supported version: SDK22
-# In current code, non-English test runs on SDK >=24
 
 for sdkver in 34
 do
@@ -28,7 +27,7 @@ do
     sdkmanager --uninstall "system-images;android-$sdkver;default;x86_64"
 done
 
-for sdkver in 24 22
+for sdkver in 22
 do
     sdkmanager "system-images;android-$sdkver;default;x86"
     echo no | avdmanager create avd -f -n vm$sdkver -k "system-images;android-$sdkver;default;x86"


### PR DESCRIPTION
It is not that some cases are not covered. The latest one covers it.