### PR TITLE
Change "keyboard based" to "keyboard-based" in the Fastlane short description

### DIFF
--- a/fastlane/metadata/android/en-US/short_description.txt
+++ b/fastlane/metadata/android/en-US/short_description.txt
@@ -1,1 +1,1 @@
-Keyboard based launcher
+Keyboard-based launcher


### PR DESCRIPTION
I think having a dash in the middle is better grammatically.