### PR TITLE
Drop Android 5.1, now supports >=6.0, and update androidx.activity

### DIFF
--- a/.github/workflows/android-connectedcheck.yml
+++ b/.github/workflows/android-connectedcheck.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        api-level: [22, 35]
+        api-level: [23, 35]
 
     steps:
       - name: checkout

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,7 +13,7 @@ android {
         versionCode 43
         versionName "1.2.24"
 
-        minSdkVersion 22
+        minSdkVersion 23
         targetSdkVersion 36
         
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -44,7 +44,7 @@ android {
 dependencies {
     implementation 'androidx.appcompat:appcompat:1.7.1'
     implementation 'androidx.preference:preference:1.2.1'
-    implementation 'androidx.activity:activity:1.8.2'
+    implementation 'androidx.activity:activity:1.12.4'
 
     testImplementation 'junit:junit:4.13.2'
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -240,6 +240,7 @@
         \n- kotlin-stdlib
         \n- JetBrains Java Annotations
         \n- Google Guava
+        \n- JSpecify
     </string>
 
     <!-- Legal English texts -->

--- a/ci/android-connectedcheck.sh
+++ b/ci/android-connectedcheck.sh
@@ -27,7 +27,7 @@ do
     sdkmanager --uninstall "system-images;android-$sdkver;default;x86_64"
 done
 
-for sdkver in 22
+for sdkver in 23
 do
     sdkmanager "system-images;android-$sdkver;default;x86"
     echo no | avdmanager create avd -f -n vm$sdkver -k "system-images;android-$sdkver;default;x86"

--- a/ci/license-checker.py
+++ b/ci/license-checker.py
@@ -49,7 +49,11 @@ def main():
             package_info = line[len('+--- '):].split(':')
             package_fullname = package_info[0]
             package_name = package_info[1]
-            package_version = package_info[2].split(' -> ')[-1].split(' ')[0]
+            if len(package_info) >= 3:
+                package_version = package_info[2].split(' -> ')[-1].split(' ')[0]
+            else:
+                package_name = package_info[1].split(' -> ')[0]
+                package_version = package_info[1].split(' -> ')[1].split(' ')[0]
 
             library_dict = {
                 'fullname': package_fullname,
@@ -63,6 +67,7 @@ def main():
                     and not package_name.startswith('kotlin-coroutines')\
                     and not package_name.startswith('kotlinx-coroutines')\
                     and not (package_name == 'annotations' and package_fullname == 'org.jetbrains')\
+                    and package_fullname != 'org.jspecify'\
                     and package_fullname != 'com.google.guava':
                 print("Line: " + line)
                 print('ERROR: Unknown package')


### PR DESCRIPTION
The latest androidx.activity requires SDK version >=23.

Updating androidx.activity is not a mandatory yet, but preventing update is a risk.

Here, Android 5.1 is version of more than 10 years.

And Blue Line Console have contact privilege. In case of Android 6.0, just declaring contact privilege is not enough and the user have to allow explicitly by dialog. But running in Android 5.1 means that this app can access to contact even if user does not want. This app actually does not, but not the desired status.

And dropping does not mean users of Android 5.1 will no longer be able to use Blue Line Console. Installed version continue to work. Just newly installing is difficult, but yet just installing older version is not blocked.

For these reasons, I decided to drop Android 5.1 support from next release.