### PR TITLE
Bump version to 1.2.25

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
     namespace 'net.nhiroki.bluelineconsole'
     defaultConfig {
         applicationId "net.nhiroki.bluelineconsole"
-        versionCode 43
-        versionName "1.2.24"
+        versionCode 44
+        versionName "1.2.25"
 
         minSdkVersion 23
         targetSdkVersion 36


### PR DESCRIPTION
As this version drops Android 5.1 support I thought about changing minor version, but in 2026, dropping Android 5.1 is not to say "compatibility change". So just updating patch version for now.